### PR TITLE
Changed Python Environment to Version 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,32 @@
-Code/.venv/
+# Exclude virtual environments
+venv/
+venv_3.11/
+
+# Large datasets or unnecessary text files
 Code/glove.42B.300d.txt
+Code/glove.6B.200d.txt
+Code/AccessibilityReportTEXT.txt
+
+# Exclude all __pycache__ directories and compiled Python files
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Exclude specific files in the project
+Code/MotorEase.py
+Code/detectors/Visual/TouchTarget.py
+Code/detectors/Visual/UIED-master/data/Input/placeholder.rtf
+MotorEase.py
+
+# Ignore all files in data/input
+Code/detectors/Visual/UIED-master/data/input/
+
+# General exclusions for temporary files
+*.log
+*.tmp
+*.bak
+
+# Exclude system files
+.DS_Store
+Thumbs.db

--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -109,7 +109,9 @@ os.chdir(MotorEase_PATH)
 
 
 AppPath = MotorEase_PATH + 'Data'
-RunDetectors(AppPath) 
+RunDetectors(AppPath)
+
+
 
 
 

--- a/Code/MotorEase.py
+++ b/Code/MotorEase.py
@@ -24,7 +24,7 @@ Congfig = importlib.import_module("detectors.Visual.UIED-master.config.CONFIG_UI
 def RunDetectors(data_folder):
 	print(">> Extracting Path\n")
 	txt = open("AccessibilityReportTEXT.txt", "a")
-	txt = open("predictions2.txt", "a")
+	#txt = open("predictions2.txt", "a")
 	file_extensions = ['.png', '.xml']
 	files = []
 	print(">> Getting Files and Screenshots\n")
@@ -44,7 +44,7 @@ def RunDetectors(data_folder):
 
 
 	model = {}
-	with open("./Code/glove.42B.300d.txt", 'r', encoding='utf-8') as file:
+	with open("glove.6B.200d.txt", 'r', encoding='utf-8') as file:
 		for line in file:
 			parts = line.split()
 			word = parts[0]
@@ -108,7 +108,7 @@ MotorEase_PATH = "./"
 os.chdir(MotorEase_PATH)
 
 
-AppPath = MotorEase_PATH + 'data'
+AppPath = MotorEase_PATH + 'Data'
 RunDetectors(AppPath) 
 
 

--- a/Code/requirements.txt
+++ b/Code/requirements.txt
@@ -5,6 +5,8 @@ charset-normalizer==3.3.2
 click==8.1.7
 confection==0.1.4
 cymem==2.0.8
+en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.5.0/en_core_web_trf-3.5.0-py3-none-any.whl#sha256=8902305d2ced83d98a8e88efd93ea8970a70dda9bb24b0024a8b798d1cc913d5
+en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.0/en_core_web_sm-2.2.0.tar.gz#sha256=65cea113d7509d5ab515583bbcbc9a31b4157bebbb73133d4110d2945476eaa4
 filelock==3.13.1
 fsspec==2023.12.2
 gensim==4.3.1
@@ -17,7 +19,19 @@ MarkupSafe==2.1.3
 mpmath==1.3.0
 murmurhash==1.0.10
 networkx==3.2.1
-numpy
+numpy==1.26.4
+nvidia-cublas-cu12==12.1.3.1
+nvidia-cuda-cupti-cu12==12.1.105
+nvidia-cuda-nvrtc-cu12==12.1.105
+nvidia-cuda-runtime-cu12==12.1.105
+nvidia-cudnn-cu12==9.1.0.70
+nvidia-cufft-cu12==11.0.2.54
+nvidia-curand-cu12==10.3.2.106
+nvidia-cusolver-cu12==11.4.5.107
+nvidia-cusparse-cu12==12.1.0.106
+nvidia-nccl-cu12==2.20.5
+nvidia-nvjitlink-cu12==12.6.85
+nvidia-nvtx-cu12==12.1.105
 opencv-python==4.7.0.68
 packaging==23.2
 pandas==1.5.3
@@ -33,7 +47,7 @@ PyYAML==6.0.1
 regex==2023.12.25
 requests==2.31.0
 safetensors==0.4.1
-scikit-learn
+scikit-learn==1.5.2
 scipy==1.10.0
 six==1.16.0
 smart-open==6.4.0
@@ -47,12 +61,11 @@ sympy==1.12
 thinc==8.1.12
 threadpoolctl==3.2.0
 tokenizers==0.13.3
-en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.5.0/en_core_web_trf-3.5.0-py3-none-any.whl#sha256=8902305d2ced83d98a8e88efd93ea8970a70dda9bb24b0024a8b798d1cc913d5
-en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.0/en_core_web_sm-2.2.0.tar.gz#sha256=65cea113d7509d5ab515583bbcbc9a31b4157bebbb73133d4110d2945476eaa4
-torch
-torchvision
+torch==2.4.1
+torchvision==0.19.1
 tqdm==4.66.1
 transformers==4.30.2
+triton==3.0.0
 typer==0.7.0
 typing_extensions==4.9.0
 urllib3==2.1.0

--- a/Code/requirements.txt
+++ b/Code/requirements.txt
@@ -70,4 +70,3 @@ typer==0.7.0
 typing_extensions==4.9.0
 urllib3==2.1.0
 wasabi==1.1.2
-

--- a/Code/requirements.txt
+++ b/Code/requirements.txt
@@ -70,3 +70,4 @@ typer==0.7.0
 typing_extensions==4.9.0
 urllib3==2.1.0
 wasabi==1.1.2
+

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Set the global version of Python to 3.12.
     ```pyenv global 3.11.0```
 5) If needed, you can switch back to Python 3.9
     ```pyenv global 3.9.0```
+    
 
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,45 @@ The MotorEase code and data has been permanently archived on Zenodo at: [https:/
 - If you would like to run MotorEase on your own screenshot/xml pair, remove existing data in the data folder and add PNG screenshots and their XML files from a single
   application.
 
+## Update Python Environment to Python 3.11
 
+-If you have not done so, please try MotorEase on Python 3.9.13 and Pip 23.3.2 to ensure functionality.
+1) Check that your current version of Python is 3.9.13 using the command  
+    ```python3 --version```
+2) Next step would be to install Python 3.11 using `apt` if on Ubunntu/Debian. Use the following commands 
+    ```sudo add-apt-repository ppa:deadsnakes/ppa``` followed by 
+    ```sudo apt update``` and 
+    ```sudo apt install python3.11 python3.11-venv python3.11-dev```
+  for the Python version and it's associated virtual environment.
+3) Create a new Python Virtual Environment in the MotorEase project directory using Python 3.11.
+    ```python3.11 -m venv venv_3.11```
+  Once the environment is created, activate it using
+    ```source venv_3.11/bin/activate```
+4) Install the requirements.txt in the virtual environment.
+    ```pip install -r requirements.txt```
+5) To see which dependencies are outdated use this command
+    ```pip list --outdated```
+6) Update all of the packages using this command.
+    ```pip install --upgrade -r requirements.txt```
+7) To reflect the newest dependencies added and updated in the requirements file, use the following command.
+    ```pip freeze > requirements.txt```
+8) Run MotorEase to see that it functions as expected.
+    ```python3 MotorEase.py```
+
+## Switching Between Python Versions
+- If needed, you can switch between Python versions using `pyenv` for managing different versions.
+1) You would first need to install `pyenv`.
+    ```curl https://pyenv.run | bash```
+2) Navigate to the home/user directory on Linux/MacOS/wsl and locate `.bashrc` or `.zshrc` file and add the following code for the exporting path of `pyenv`. 
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init --path)"
+eval "$(pyenv virtualenv-init -)"
+4) Install Python 3.11 using `pyenv`.
+    ```pyenv install 3.11.0```
+Set the global version of Python to 3.12.
+    ```pyenv global 3.11.0```
+5) If needed, you can switch back to Python 3.9
+    ```pyenv global 3.9.0```
 
 
 

--- a/README.md
+++ b/README.md
@@ -70,40 +70,42 @@ The MotorEase code and data has been permanently archived on Zenodo at: [https:/
 
 ## Update Python Environment to Python 3.11
 
--If you have not done so, please try MotorEase on Python 3.9.13 and Pip 23.3.2 to ensure functionality.
+- If you have not done so, please try MotorEase on Python 3.9.13 and Pip 23.3.2 to ensure functionality.
 1) Check that your current version of Python is 3.9.13 using the command  
-    ```python3 --version```
+    - ```python3 --version```
 2) Next step would be to install Python 3.11 using `apt` if on Ubunntu/Debian. Use the following commands 
-    ```sudo add-apt-repository ppa:deadsnakes/ppa``` followed by 
-    ```sudo apt update``` and 
-    ```sudo apt install python3.11 python3.11-venv python3.11-dev```
+    - ```sudo add-apt-repository ppa:deadsnakes/ppa``` followed by 
+    - ```sudo apt update``` and 
+    - ```sudo apt install python3.11 python3.11-venv python3.11-dev```
   for the Python version and it's associated virtual environment.
-3) Create a new Python Virtual Environment in the MotorEase project directory using Python 3.11.
-    ```python3.11 -m venv venv_3.11```
+3) switch to Python 3.11
+   - ```pyenv global 3.11```
+4) Create a new Python Virtual Environment in the MotorEase project directory specifically the Code folder, using Python 3.11.
+   - ```python3.11 -m venv venv_3.11```
   Once the environment is created, activate it using
-    ```source venv_3.11/bin/activate```
-4) Install the requirements.txt in the virtual environment.
-    ```pip install -r requirements.txt```
-5) To see which dependencies are outdated use this command
-    ```pip list --outdated```
-6) Update all of the packages using this command.
-    ```pip install --upgrade -r requirements.txt```
-7) To reflect the newest dependencies added and updated in the requirements file, use the following command.
-    ```pip freeze > requirements.txt```
-8) Run MotorEase to see that it functions as expected.
-    ```python3 MotorEase.py```
+    - ```source venv_3.11/bin/activate```
+5) Install the requirements.txt in the virtual environment.
+    - ```pip install -r requirements.txt```
+6) To see which dependencies are outdated use this command
+    - ```pip list --outdated```
+7) Update all of the packages using this command.
+    - ```pip install --upgrade -r requirements.txt```
+8) To reflect the newest dependencies added and updated in the requirements file, use the following command.
+    - ```pip freeze > requirements.txt```
+9) Run MotorEase to see that it functions as expected.
+    - ```python3 MotorEase.py```
 
 ## Switching Between Python Versions
 - If needed, you can switch between Python versions using `pyenv` for managing different versions.
 1) You would first need to install `pyenv`.
     ```curl https://pyenv.run | bash```
 2) Navigate to the home/user directory on Linux/MacOS/wsl and locate `.bashrc` or `.zshrc` file and add the following code for the exporting path of `pyenv`. 
-export PATH="$HOME/.pyenv/bin:$PATH"
-eval "$(pyenv init --path)"
-eval "$(pyenv virtualenv-init -)"
+- export PATH="$HOME/.pyenv/bin:$PATH"
+- eval "$(pyenv init --path)"
+- eval "$(pyenv virtualenv-init -)"
 4) Install Python 3.11 using `pyenv`.
     ```pyenv install 3.11.0```
-Set the global version of Python to 3.12.
+Set the global version of Python to 3.11.
     ```pyenv global 3.11.0```
 5) If needed, you can switch back to Python 3.9
     ```pyenv global 3.9.0```


### PR DESCRIPTION
### What?
I've updated the the Python environment from 3.9.13 to 3.11. The documentation for how to change environment as well as switch between them is provided in the README. The requirement.txt file was also changed to reflect the latest versions of dependencies along with newly added ones.

### Why?
Python 3.9 reached its end of life in October of 2023. MotorEase is an application that was created for research purposes. Researchers will need stable versions of Python to faithfully attempt a replication of the results that MotorEase produced. Updating the environment and its dependencies also extends the lifespan of MotorEase for future use.

### How?
The WSL terminal was used to install Python 3.11 and its associated virtual environment. Utilizing the virtual environment, i was able to list out what dependencies were outdated and replace them with newer versions. I also used the environment to regenerate the requirements.txt file with all of thee latest dependencies. The documentation for setting up the new environment was changed to include these updates.

### Testing?
No formal unit tests or automated tests were performed. Instead, the new Python environment was validated by running the application on 3.11 and seeing if the program functioned as expected.

### Screenshots
![verify version](https://github.com/user-attachments/assets/e6adfac1-f8a8-43b9-9953-02f66a2ced2d)
![Switching versions](https://github.com/user-attachments/assets/2134fdaf-ec5a-4619-b745-7fec7672626f)
![Creating seperate environment](https://github.com/user-attachments/assets/40bb68c8-ebad-49fd-b61b-5a0c2a808a4d)
![List of Outdated Dependencies](https://github.com/user-attachments/assets/060a4b65-60e7-43f9-8f3c-f93367bb8a94)
![Updated Requirement's](https://github.com/user-attachments/assets/df8f8cc5-4aec-4c2e-b370-0b4563771664)
![list of depends](https://github.com/user-attachments/assets/c60b188a-8f58-4faa-be8f-1fdfea03bc55)

### Anything Else?

-  As of writing, Python 3.11 is the highest version of python that can be used. 3.12 has incompatibility issues with some dependencies and others have been yanked
- I was unable to reproduce the results from the originating repository
- The changes possible for this project were limited by my knowledge of Docker and Python
- pyenv was also used to allow for easy management of different environment versions
- Alternatively you could remove any environments that you do not want to use from the project directory